### PR TITLE
feat: add clawbio_baseline_ref for before/after delta reports

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: ''
         type: string
+      clawbio_baseline_ref:
+        description: 'ClawBio commit to compare against (produces delta report)'
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: write          # baseline commit + push
@@ -32,6 +37,16 @@ jobs:
             exit 1
           fi
 
+      - name: Validate clawbio_baseline_ref
+        if: inputs.clawbio_baseline_ref != ''
+        env:
+          CB_BASE: ${{ inputs.clawbio_baseline_ref }}
+        run: |
+          if ! printf '%s' "${CB_BASE}" | grep -Eq '^[A-Fa-f0-9a-z._/-]+$'; then
+            echo "::error::Invalid clawbio_baseline_ref: contains disallowed characters"
+            exit 1
+          fi
+
       - name: Checkout ClawBio
         uses: actions/checkout@v4
         with:
@@ -48,7 +63,24 @@ jobs:
       - name: Install bench
         run: pip install -e ".[all,dev]"
 
-      # ── Run smoke suite against ClawBio HEAD ──
+      # ── Run baseline audit (when comparing two commits) ──
+      - name: Run baseline audit
+        if: inputs.clawbio_baseline_ref != ''
+        env:
+          CB_BASE: ${{ inputs.clawbio_baseline_ref }}
+        run: |
+          set +e
+          clawbio-bench --commits "${CB_BASE}" \
+            --repo clawbio \
+            --output results/baseline/ \
+            --allow-dirty \
+            --no-rich
+          exit_code=$?
+          set -e
+          echo "Baseline audit exited with code ${exit_code}"
+          if [ $exit_code -ge 2 ]; then exit $exit_code; fi
+
+      # ── Run smoke suite against ClawBio HEAD (or clawbio_ref) ──
       - name: Run smoke suite
         id: smoke
         run: |
@@ -70,32 +102,39 @@ jobs:
 
       # ── Delta report (markdown) ──
       - name: Generate markdown delta report
+        env:
+          HAS_BASELINE_RUN: ${{ inputs.clawbio_baseline_ref != '' }}
         run: |
-          if [ -f baselines/latest_baseline.json ]; then
-            clawbio-bench --render-markdown results/today/ \
-              --baseline baselines/latest_baseline.json \
-              --markdown-output results/today/report.md \
-              --no-rich
-          else
-            clawbio-bench --render-markdown results/today/ \
-              --markdown-output results/today/report.md \
-              --no-rich
+          BASELINE_ARG=""
+          if [ "${HAS_BASELINE_RUN}" = "true" ] && [ -f results/baseline/aggregate_report.json ]; then
+            BASELINE_ARG="--baseline results/baseline/aggregate_report.json"
+          elif [ -f baselines/latest_baseline.json ]; then
+            BASELINE_ARG="--baseline baselines/latest_baseline.json"
           fi
+          # shellcheck disable=SC2086  # intentional word-splitting on BASELINE_ARG
+          clawbio-bench --render-markdown results/today/ \
+            ${BASELINE_ARG} \
+            --markdown-output results/today/report.md \
+            --no-rich
 
       # ── Delta report (PDF via Typst) ──
       - name: Install Typst
         uses: typst-community/setup-typst@v4
 
       - name: Generate PDF report
+        env:
+          HAS_BASELINE_RUN: ${{ inputs.clawbio_baseline_ref != '' }}
         run: |
-          if [ -f baselines/latest_baseline.json ]; then
-            python scripts/generate_report.py results/today/ \
-              --baseline baselines/latest_baseline.json \
-              --output results/today/report.pdf
-          else
-            python scripts/generate_report.py results/today/ \
-              --output results/today/report.pdf
+          BASELINE_ARG=""
+          if [ "${HAS_BASELINE_RUN}" = "true" ] && [ -f results/baseline/aggregate_report.json ]; then
+            BASELINE_ARG="--baseline results/baseline/aggregate_report.json"
+          elif [ -f baselines/latest_baseline.json ]; then
+            BASELINE_ARG="--baseline baselines/latest_baseline.json"
           fi
+          # shellcheck disable=SC2086
+          python scripts/generate_report.py results/today/ \
+            ${BASELINE_ARG} \
+            --output results/today/report.pdf
 
       # ── Baseline management ──
       - name: Update baseline if improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `clawbio_ref` input for auditing historical commits (e.g.
   `clawbio_ref: 349fb98` to audit the pre-remediation state). Historical
   runs produce full reports, baselines, and digests but suppress automatic
-  issue creation to avoid false alarms.
+  issue creation to avoid false alarms. A second optional input
+  `clawbio_baseline_ref` runs the bench against a baseline commit first,
+  then uses its aggregate as the `--baseline` for the main run's delta
+  report — producing a single workflow run with a proper before/after
+  comparison (e.g. `clawbio_baseline_ref: 349fb98` + default
+  `clawbio_ref` = "April 2 vs HEAD").
 - **`scripts/update_baseline.py`.** Baseline manager: promotes on strict
   improvement, initializes on first run, handles corrupt baselines.
 - **`scripts/post_summary.py` with multi-model LLM swarm.** `--llm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # clawbio-bench
 
+```
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⠛⠉⠉⠉⠈⠉⠉⠙⠛⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠋⠀⠀⢀⣠⣤⣤⣤⣤⣤⣤⣄⡀⠈⠛⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠋⠀⢀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⡀⠈⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠁⠀⣠⣾⣿⣿⣿⣿⡿⢿⠛⡟⢿⣿⣿⣿⣿⣷⠀⠀⢹⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⢠⣿⣿⣿⣿⣿⡿⡋⠃⠈⠀⠀⠈⠈⢻⣿⣿⣿⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡃⣿⣿⣿⣿⣿⡏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣻⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠹⣿⣿⣿⣿⣿⣦⡂⡀⠀⠀⠀⠀⠀⣰⣶⣶⣶⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣷⠀⠉⠻⣿⣿⣿⣿⣿⣧⣼⣀⣆⣼⣾⣿⣿⣿⣿⠀⠀⢰⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣧⡀⠀⠘⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠃⠀⣠⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠛⣿⣿⣄⡀⠀⠈⠙⠻⠿⠿⠿⠿⠿⠿⠟⠋⠀⣀⣼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⣿⣿⠿⠃⠀⢀⣼⣿⣿⣿⣦⣄⣀⠀⠀⠀⠀⠀⠀⢀⣀⣤⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⣿⣿⣿⠟⠉⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣿⣿⡿⢋⠁⢀⣤⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⢟⠉⠀⣠⣼⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+⣷⣤⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿
+```
+
 [![Version](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbiostochastics%2Fclawbio_bench%2Fmain%2Fpyproject.toml&query=%24.project.version&prefix=v&label=version&color=blue)](https://github.com/biostochastics/clawbio_bench/releases)
 [![Python](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbiostochastics%2Fclawbio_bench%2Fmain%2Fpyproject.toml&query=%24.project.%22requires-python%22&label=python&color=blue)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
@@ -1432,12 +1450,14 @@ every morning at 8 AM UTC against ClawBio HEAD:
 
 Secrets: `NOTIFICATION_WEBHOOK` (optional), `OPENROUTER_API_KEY`
 (optional, enables LLM swarm digest). The workflow also supports
-`workflow_dispatch` for manual triggering with an optional `clawbio_ref`
-input to audit a specific ClawBio commit, tag, or branch (e.g.
-`clawbio_ref: 349fb98` to audit the pre-remediation state). Historical
-runs produce full reports, baselines, and digests but suppress automatic
-issue creation to avoid false alarms. The ref input is validated against
-a conservative character set before use.
+`workflow_dispatch` for manual triggering with two optional inputs:
+`clawbio_ref` audits a specific ClawBio commit/tag/branch instead of
+HEAD; `clawbio_baseline_ref` runs the bench against a baseline commit
+first and uses its aggregate for the delta report — producing a single
+workflow run with a proper before/after comparison (e.g.
+`clawbio_baseline_ref: 349fb98` = "April 2 vs today"). Historical
+runs suppress automatic issue creation. Both ref inputs are validated
+against a conservative character set before use.
 
 ---
 


### PR DESCRIPTION
## **User description**
When `clawbio_baseline_ref` is provided via workflow_dispatch, the daily-audit workflow first runs the bench against the baseline commit, then uses its aggregate_report.json as the `--baseline` for the main run's markdown and PDF delta reports. Produces a single workflow run with a proper before/after comparison (e.g. April 2 vs HEAD).


___

## **CodeAnt-AI Description**
**Add a manual baseline input for before/after audit reports**

### What Changed
- Manual audit runs can now compare today’s results against a chosen baseline commit and produce a single before/after delta report.
- The new baseline input is checked for invalid characters before the workflow runs.
- If no baseline is provided, the report continues to use the existing default comparison source.
- The README and changelog now describe the new manual audit option.

### Impact
`✅ Clearer before/after audit reports`
`✅ Easier historical ClawBio comparisons`
`✅ Fewer invalid manual workflow runs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
