### PR TITLE
fix(equity): correct eq_15 GROUND_TRUTH_FST 0.500 -> 1.000

### DIFF
--- a/src/clawbio_bench/test_cases/equity/eq_15_three_populations/ground_truth.txt
+++ b/src/clawbio_bench/test_cases/equity/eq_15_three_populations/ground_truth.txt
@@ -1,6 +1,6 @@
 # BENCHMARK: equity-scorer v0.1.0
 # PAYLOAD: input.vcf
-# GROUND_TRUTH_FST: 0.500
+# GROUND_TRUTH_FST: 1.000
 # GROUND_TRUTH_FST_ESTIMATOR: Nei's GST
 # GROUND_TRUTH_FST_PAIR: POP_A_vs_POP_B
 # FST_TOLERANCE: 0.02
@@ -12,10 +12,20 @@
 # REFERENCE_GENOME: GRCh38
 # NEI_REF: NEI_1973
 # DERIVATION: 3 pops x 5 samples. POP_A all 1/1, POP_B all 0/0, POP_C all 0/1.
-#   Targets: POP_A_vs_POP_B=1.0 (perfect differentiation),
-#            POP_A_vs_POP_C=0.33, POP_B_vs_POP_C=0.33.
-#   This test verifies the harness catches silent fallback to the first pair
-#   when ground truth has no GROUND_TRUTH_FST_PAIR — but here we DO specify
-#   the pair, so scoring must use POP_A_vs_POP_B specifically. A tool that
-#   emits POP_A_vs_POP_C as first pair must not be credited.
+#   Per-pair Nei GST (analytic, identical at all 10 loci):
+#     POP_A_vs_POP_B: p_A=1.0, p_B=0.0  -> H_S=0, p_T=0.5, H_T=0.5
+#                     -> GST = (0.5 - 0)/0.5 = 1.0  (perfect differentiation)
+#     POP_A_vs_POP_C: p_A=1.0, p_C=0.5  -> H_S=0.25, p_T=0.75, H_T=0.375
+#                     -> GST = (0.375 - 0.25)/0.375 = 0.333
+#     POP_B_vs_POP_C: p_B=0.0, p_C=0.5  -> H_S=0.25, p_T=0.25, H_T=0.375
+#                     -> GST = 0.333
+#   GROUND_TRUTH_FST_PAIR pins this test to POP_A_vs_POP_B = 1.0. The test
+#   verifies the harness scores the requested pair specifically and does
+#   NOT silently fall back to the first pair the tool happens to emit
+#   (e.g. POP_A_vs_POP_C). A tool that emits POP_A_vs_POP_C first must
+#   not be credited just because 0.333 happens to lie within tolerance of
+#   some other pair.
+#   Corrected 2026-04-07: GROUND_TRUTH_FST was 0.500, which matched no
+#   pairwise or global Nei GST on this VCF. Caught by Manuel/POP during
+#   v0.1.3 remediation re-run.
 # DESIGN: Uses 3 populations to force multi-pair output.


### PR DESCRIPTION
## **User description**
## Summary

- Manuel/POP caught this during the v0.1.3 remediation re-run against ClawBio `237cbd9`: `eq_15`'s `GROUND_TRUTH_FST` was set to `0.500`, but Nei's GST for `POP_A_vs_POP_B` on this VCF is mathematically **1.0**.
- The `DERIVATION` comment in the same file already said `POP_A_vs_POP_B=1.0 (perfect differentiation)` — only the scalar field was wrong (transcription bug).
- Expanded the derivation block to spell out all three pairwise GST values explicitly and added an inline correction note dated 2026-04-07.

## Math

POP_A all `1/1` → p_A = 1.0; POP_B all `0/0` → p_B = 0.0

```
h_A = 1 - 1 - 0 = 0
h_B = 1 - 0 - 1 = 0
H_S = 0
p_T = 0.5,  q_T = 0.5
H_T = 1 - 0.25 - 0.25 = 0.5
GST = (0.5 - 0) / 0.5 = 1.0
```

`0.500` matches no pairwise or global Nei value on this VCF (POP_A_vs_POP_C = POP_B_vs_POP_C = 1/3, global = 2/3). It looks like someone wrote `(p_A + p_B)/2` by mistake.

## Test plan

- [x] `ruff format src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/ -q -k "not test_harness_smoke"` — 245 passed
- [ ] Manuel re-runs the equity harness against ClawBio `237cbd9`; expect `eq_15` to flip to `fst_correct` (their remediated tool already reports ~1.0)


___

## **CodeAnt-AI Description**
**Correct the expected FST value for the three-population equity test**

### What Changed
- Fixed the expected score for the POP_A_vs_POP_B case from 0.500 to 1.000.
- Expanded the test notes to show the expected Nei GST for all three population pairs, so the intended match is clear.
- Added a correction note explaining that the previous value was wrong and that this test must score the specified pair, not whichever pair appears first.

### Impact
`✅ Fewer false test failures`
`✅ Clearer equity benchmark results`
`✅ Correct scoring for the intended population pair`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
