### PR TITLE
refactor(daily-pipeline): neutralize language, fix verify bug, incremental changelog

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    outputs:
+      has_regression: ${{ steps.delta.outputs.has_regression }}
     steps:
       - uses: actions/checkout@v4
 
@@ -62,6 +64,24 @@ jobs:
 
       - name: Install bench
         run: pip install -e ".[all,dev]"
+
+      # ── Download rolling baseline from audit-baseline.yml ──
+      # The baseline is published as a release asset at 04:17 UTC.
+      # Downloading it here avoids re-running the smoke suite twice
+      # against the same ClawBio HEAD.
+      - name: Download rolling baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p baselines
+          if gh release download baseline-main \
+              --pattern aggregate_report.json \
+              --output baselines/latest_baseline.json \
+              --clobber 2>/dev/null; then
+            echo "Downloaded baseline-main release asset."
+          else
+            echo "No baseline-main release found — first run or release missing."
+          fi
 
       # ── Run baseline audit (when comparing two commits) ──
       - name: Run baseline audit
@@ -115,6 +135,23 @@ jobs:
       - name: Verify artifacts generated
         run: |
           test -f results/today/aggregate_report.json
+
+      - name: Detect regression vs baseline
+        id: delta
+        run: |
+          has_regression=false
+          if [ -f baselines/latest_baseline.json ]; then
+            has_regression=$(python3 -c "
+          import json, sys
+          cur = json.load(open('results/today/aggregate_report.json'))
+          base = json.load(open('baselines/latest_baseline.json'))
+          cur_rate = (cur.get('overall') or {}).get('total_pass_rate', 0.0)
+          base_rate = (base.get('overall') or {}).get('total_pass_rate', 0.0)
+          print('true' if cur_rate < base_rate else 'false')
+          " 2>/dev/null || echo "false")
+          fi
+          echo "has_regression=$has_regression" >> "$GITHUB_OUTPUT"
+          echo "Regression detected: $has_regression"
 
       # ── Delta report (markdown) ──
       - name: Generate markdown delta report
@@ -250,11 +287,11 @@ jobs:
               const overall = agg.overall || {};
               const rate = overall.total_pass_rate || 0;
               const commit = agg.clawbio_commit || 'unknown';
-              const blocking = (overall.blocking_skills || []).join(', ') || 'none';
+              const withFindings = (overall.blocking_skills || []).join(', ') || 'none';
               body = [
                 `**Daily audit:** ${overall.total_pass || 0}/${overall.total_evaluated || 0} (${rate}%)`,
                 `**ClawBio commit:** \`${commit}\``,
-                `**Blocking harnesses:** ${blocking}`,
+                `**Harnesses with findings:** ${withFindings}`,
                 '',
                 `See [workflow run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}) for full artifacts.`,
               ].join('\n');
@@ -267,7 +304,7 @@ jobs:
             const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'regression,automated',
+              labels: 'audit-findings,automated',
               state: 'open',
             });
             const alreadyOpen = existing.data.some(i => i.title.includes(today));
@@ -279,15 +316,17 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Regression detected: ${today}`,
+              title: `Audit findings: ${today}`,
               body: body,
-              labels: ['regression', 'automated'],
+              labels: ['audit-findings', 'automated'],
             });
 
-  # ── Watch-commits mode: per-commit attribution on regression ──
+  # ── Watch-commits mode: per-commit attribution on actual regression ──
   regression-sweep:
     needs: [audit]
-    if: always() && (needs.audit.result == 'success' || needs.audit.result == 'failure')
+    if: >-
+      always()
+      && needs.audit.outputs.has_regression == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.5] — 2026-04-14
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and percentile boundary validation. Total suite: 10 harnesses, 183 test
   cases. (PR #19, Manuel Corpas)
 
+### Changed
+
+- **Softened daily report language.** All LLM system prompts now use
+  neutral, constructive phrasing: "areas for improvement" instead of
+  "worst performers", "clinical considerations" instead of "clinical
+  risks", "declined" instead of "regression", "recurring themes" instead
+  of "systemic issues". GitHub issue titles changed from "Regression
+  detected" to "Audit findings" with matching label rename.
+
+- **Investigation prompt scoped to coverage gaps only.** The
+  investigation section no longer re-analyzes per-harness pass rates
+  (already covered by the digest). It receives a compact category-only
+  summary instead of the full aggregate JSON, eliminating redundant LLM
+  analysis and reducing token consumption.
+
+- **Self-changelog is now incremental.** Tracks the last-summarized
+  clawbio-bench commit SHA in `baselines/log/state.json` and uses
+  `git log <last_sha>..HEAD` instead of a 7-day sliding window. Each
+  daily report now contains only new changes, eliminating the 6/7-day
+  content overlap between consecutive runs.
+
+- **ClawBio diff uses explicit commit ranges.** Tracks the last-audited
+  ClawBio commit in `baselines/log/state.json` and diffs against it
+  instead of using a rolling `HEAD~5` window. No more stale changes
+  reappearing in consecutive daily reports.
+
+- **Regression sweep gated on actual decline.** The `regression-sweep`
+  CI job now runs only when the daily audit detects a pass-rate drop
+  vs baseline, instead of running unconditionally on every daily run.
+
+- **Daily audit downloads rolling baseline.** `daily-audit.yml` now
+  downloads the `baseline-main` release asset (published by
+  `audit-baseline.yml` at 04:17 UTC) instead of relying solely on a
+  repo-committed baseline, ensuring consistent delta comparisons.
+
 ### Fixed (review of PR #19)
 
 - **`harness_error_verdict` called with wrong kwargs** — PR used `error=`
@@ -53,6 +88,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output no longer raises `JSONDecodeError`.
 - **Removed unused `variants` parameter** from `score_prs_verdict` and
   removed dead `parse_prs_variants` function.
+
+### Fixed
+
+- **Polish pass verified against original aggregate.** `_verify_numbers`
+  in `write_daily_log` was passing an empty `{}` for the aggregate
+  parameter, allowing numbers fabricated by the LLM swarm to survive
+  the polish pass unchecked. Now passes the original `aggregate` dict
+  so all numbers are verified against ground truth.
 
 ## [0.1.4] — 2026-04-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawbio-bench"
-version = "0.1.4"
+version = "0.1.5"
 description = "ClawBio Benchmark Suite — machine-readable harnesses for auditing bioinformatics tools"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/guard_ground_truth.py
+++ b/scripts/guard_ground_truth.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: block edits to load-bearing audit artifacts.
+
+Protected paths:
+  - test_cases/**/ground_truth.txt  (audit contract ground truth)
+  - schemas/*.json                  (canonical JSON Schema artifacts)
+  - results/**                      (committed verdict baselines)
+
+Exit 0  = allow
+Exit 2  = block (with reason on stderr)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PROTECTED_PATTERNS: list[tuple[str, str]] = [
+    # (path component test, human-readable reason)
+    (
+        "test_cases/",
+        "Ground-truth files define the audit contract. "
+        "Edits change what the benchmark measures. "
+        "Run the ground-truth-auditor agent first, then edit deliberately.",
+    ),
+    (
+        "schemas/",
+        "JSON Schema artifacts are the external contract for verdict consumers. "
+        "Regenerate via `python scripts/gen_schemas.py`, don't hand-edit.",
+    ),
+    (
+        "results/",
+        "Committed results are the baseline for regression detection. "
+        "Use `clawbio-bench` to regenerate, don't hand-edit.",
+    ),
+]
+
+
+def is_protected(file_path: str) -> tuple[bool, str]:
+    """Check if a file path falls under a protected pattern."""
+    try:
+        resolved = Path(file_path).resolve()
+        rel = resolved.relative_to(REPO_ROOT)
+    except (ValueError, OSError):
+        return False, ""
+
+    rel_posix = rel.as_posix()
+
+    for pattern, reason in PROTECTED_PATTERNS:
+        if pattern in rel_posix:
+            # ground_truth.txt guard only applies to that specific filename
+            if pattern == "test_cases/":
+                if resolved.name != "ground_truth.txt":
+                    continue
+            return True, reason
+
+    return False, ""
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit(0)
+
+    file_path = sys.argv[1]
+    blocked, reason = is_protected(file_path)
+
+    if blocked:
+        print(
+            f"BLOCKED: {os.path.basename(file_path)} is a protected audit artifact.\n"
+            f"Reason: {reason}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/post_summary.py
+++ b/scripts/post_summary.py
@@ -136,16 +136,16 @@ def build_digest(
         delta_parts.append(f"rate {direction} {abs(delta):.1f}pp")
         parts.append("Delta: " + ", ".join(delta_parts) + ".")
 
-        # Surface specific regressions by harness
-        regression_harnesses = []
+        # Surface per-harness declines
+        declined_harnesses = []
         baseline_harnesses = baseline.get("harnesses") or {}
         for hname in harnesses:
             cur_rate = (harnesses.get(hname) or {}).get("pass_rate", 0.0)
             base_rate = (baseline_harnesses.get(hname) or {}).get("pass_rate", 0.0)
             if cur_rate < base_rate:
-                regression_harnesses.append(f"{hname} regression")
-        if regression_harnesses:
-            parts.append(", ".join(regression_harnesses) + ".")
+                declined_harnesses.append(f"{hname} declined")
+        if declined_harnesses:
+            parts.append(", ".join(declined_harnesses) + ".")
 
     return " ".join(parts)
 
@@ -193,10 +193,10 @@ validity, or therapeutic recommendations. Framework issues \
 not clinically significant.
 
 Analyze the structured audit results using markdown bullets:
-- **Clinical risks**: Any patient-safety findings (pharmgx, CVR)?
-- **Worst performers**: Which harnesses have the lowest pass rates?
+- **Clinical considerations**: Any findings with clinical relevance (pharmgx, CVR)?
+- **Areas for improvement**: Which harnesses have the lowest pass rates?
 - **Patterns**: What do new/resolved findings reveal?
-- **Trajectory**: Is the overall pass rate improving or regressing?
+- **Trajectory**: Is the overall pass rate improving or declining?
 
 RULES:
 - Do NOT perform arithmetic. Use ONLY pre-calculated values from the data.
@@ -206,12 +206,12 @@ RULES:
 
 Example of a well-formed analysis:
 "- **Clinical**: pharmgx-reporter at 54.5% with 3 omission findings \
-(warfarin, DPYD, CYP2C19) — direct patient safety risk.
-- **Worst**: clawbio-finemapping at 25.0%, driven by pip_nan_silent \
+(warfarin, DPYD, CYP2C19) — clinically relevant coverage gaps.
+- **Lowest**: clawbio-finemapping at 25.0%, driven by pip_nan_silent \
 and susie_null_forced_signal.
 - **Pattern**: 8 findings resolved in equity-scorer after FST fix, \
 but 5 new fst_mislabeled findings appeared.
-- **Trajectory**: Overall down 5.7pp to 65.0% — net regression.\""""
+- **Trajectory**: Overall down 5.7pp to 65.0% — net decline.\""""
 )
 
 SYNTHESIZER_SYSTEM_PROMPT = """\
@@ -220,8 +220,8 @@ on a bioinformatics safety audit into a single concise narrative digest.
 
 You will receive the structured audit data and 2-3 independent analyst \
 interpretations. Produce a 3-5 sentence narrative summary:
-1. Lead with the most important change (regression or improvement).
-2. Name the worst-performing harnesses with their exact pass rates.
+1. Lead with the most notable change (decline or improvement).
+2. Name the lowest-scoring harnesses with their exact pass rates.
 3. Highlight clinically significant findings if any analysts flagged them.
 4. End with the overall trajectory.
 
@@ -475,7 +475,7 @@ net pass rate change in percentage points.
 - **Movers**: Which harness improved or regressed most, named with its \
 start and end pass rates.
 - **Findings delta**: Net new vs resolved findings for the week.
-- **Persistent patterns**: Any finding category appearing 3+ days in a row.
+- **Recurring patterns**: Any finding category appearing 3+ days in a row.
 
 RULES:
 - Use ONLY numbers from the provided daily entries.
@@ -488,16 +488,16 @@ MONTHLY_SYSTEM_PROMPT = """\
 You are a bioinformatics audit trend analyst for clawbio-bench. Given \
 daily and weekly audit digests from the past month, produce a \
 markdown-formatted monthly summary with these bullets:
-- **Range**: Best and worst pass rate days, named by date.
+- **Range**: Highest and lowest pass rate days, named by date.
 - **Harness trends**: Which harnesses improved or regressed, with rates.
 - **Findings delta**: Net new vs resolved findings for the month.
-- **Systemic issues**: Recurring patterns or persistent failures.
+- **Recurring themes**: Persistent patterns or ongoing findings.
 - **Assessment**: Overall audit target health trajectory (1-2 sentences).
 
 RULES:
 - Use ONLY numbers from the provided entries.
 - Do NOT perform arithmetic — use only pre-calculated values.
-- Name specific dates when citing best/worst days.
+- Name specific dates when citing highest/lowest days.
 - If data is insufficient, state "insufficient data" for that bullet.
 - You are authorized to acknowledge uncertainty."""
 
@@ -527,28 +527,59 @@ def _today_str() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%d")
 
 
+# ---------------------------------------------------------------------------
+# Incremental state — tracks last-processed commits to avoid duplication
+# ---------------------------------------------------------------------------
+
+
+def _load_log_state(log_dir: Path) -> dict:
+    """Load the persistent log state (last processed SHAs, etc.)."""
+    state_path = log_dir / "state.json"
+    if state_path.exists():
+        try:
+            with open(state_path, encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {}
+
+
+def _save_log_state(log_dir: Path, state: dict) -> None:
+    """Persist log state for the next run."""
+    state_path = log_dir / "state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(state_path, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2)
+
+
 INVESTIGATION_SYSTEM_PROMPT = (
     """\
 You are a bioinformatics audit coverage analyst for clawbio-bench. \
 You are given:
-1. The current audit results (aggregate JSON with per-harness findings).
+1. A compact summary of current findings (category names only — the \
+   daily digest already covers per-harness pass rates and specifics).
 2. The project README describing current harness coverage.
 3. The project ROADMAP describing planned harnesses.
+
+Your job is ONLY to identify coverage gaps and forward-looking needs. \
+Do NOT restate per-harness pass rates, finding counts, or clinical \
+observations — those belong in the digest section, not here.
 
 First, reason step-by-step:
 a) List the ClawBio skills mentioned in the README.
 b) Map each to an existing harness (or note "no harness").
-c) Check the audit results for unexpected category patterns.
-d) Compare findings against ROADMAP priorities.
+c) Check for finding *categories* that suggest new test cases are needed.
+d) Compare ROADMAP priorities against current coverage.
 
 Then produce your analysis with these sections:
-- **Coverage gaps**: New ClawBio skills with no harness coverage.
+- **Coverage gaps**: ClawBio skills with no harness coverage.
 - **Test case updates needed**: Changed behavior suggesting updates.
-- **New patterns**: Finding categories suggesting new test cases.
-- **ROADMAP adjustments**: Priority changes based on current findings.
+- **New category patterns**: Finding categories suggesting new test cases.
+- **ROADMAP adjustments**: Priority changes based on current coverage.
 - **Action list** (max 5 items, prioritized).
 
 RULES:
+- Do NOT mention per-harness pass rates — that is the digest's job.
 - ONLY flag gaps for capabilities EXPLICITLY described in the provided \
 text. If sections are truncated (marked [...]), do NOT infer content.
 - Do NOT invent ClawBio skills or harness names.
@@ -656,34 +687,59 @@ def _llm_aggregate(
         return None
 
 
-def _get_clawbio_diff(clawbio_path: Path | None, days: int = 1) -> str | None:
-    """Get recent ClawBio git log + diff stat."""
+def _get_clawbio_diff(
+    clawbio_path: Path | None,
+    last_clawbio_commit: str | None = None,
+) -> str | None:
+    """Get ClawBio git log + diff stat since the last audited commit.
+
+    Uses an explicit commit range when ``last_clawbio_commit`` is known,
+    falling back to ``--since=1 days ago`` on the first run.
+    """
     if clawbio_path is None or not clawbio_path.exists():
         return None
     import subprocess
 
-    since = f"{days} days ago"
     try:
-        log_r = subprocess.run(
-            [
+        if last_clawbio_commit:
+            log_cmd = [
                 "git",
                 "-C",
                 str(clawbio_path),
                 "log",
-                f"--since={since}",
+                f"{last_clawbio_commit}..HEAD",
                 "--oneline",
                 "--no-merges",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        stat_r = subprocess.run(
-            ["git", "-C", str(clawbio_path), "diff", "--stat", "HEAD~5..HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+            ]
+            stat_cmd = [
+                "git",
+                "-C",
+                str(clawbio_path),
+                "diff",
+                "--stat",
+                f"{last_clawbio_commit}..HEAD",
+            ]
+        else:
+            log_cmd = [
+                "git",
+                "-C",
+                str(clawbio_path),
+                "log",
+                "--since=1 days ago",
+                "--oneline",
+                "--no-merges",
+            ]
+            stat_cmd = [
+                "git",
+                "-C",
+                str(clawbio_path),
+                "diff",
+                "--stat",
+                "HEAD~1..HEAD",
+            ]
+
+        log_r = subprocess.run(log_cmd, capture_output=True, text=True, timeout=10)
+        stat_r = subprocess.run(stat_cmd, capture_output=True, text=True, timeout=10)
         parts = []
         if log_r.returncode == 0 and log_r.stdout.strip():
             parts.append(f"**Recent commits:**\n```\n{log_r.stdout.strip()}\n```")
@@ -741,6 +797,7 @@ def write_daily_log(
     clawbio_raw_diff: str | None = None,
     api_key: str | None = None,
     synthesizer: str | None = None,
+    aggregate: dict | None = None,
 ) -> Path:
     """Write a consolidated daily log file with all sections.
 
@@ -806,9 +863,9 @@ def write_daily_log(
                 api_key,
                 temperature=0.1,
             )
-            # Verify against the full draft (not just structured) since
-            # the polished text includes numbers from all sections.
-            if _verify_numbers(polished, draft, {}):
+            # Verify against original aggregate to prevent fabricated
+            # numbers from surviving the polish pass.
+            if _verify_numbers(polished, draft, aggregate or {}):
                 draft = polished
                 print("  Log: final polish applied.", file=sys.stderr)
             else:
@@ -920,9 +977,25 @@ def run_investigation(
     """
     synth_model = synthesizer or DEFAULT_SYNTHESIZER_MODEL
 
+    # Build a compact category-only summary — pass rates and finding
+    # details are covered by the digest, so we only send category names
+    # and harness names to avoid prompting the LLM to restate them.
+    compact: dict = {
+        "harnesses": {},
+    }
+    for hname, hdata in (aggregate.get("harnesses") or {}).items():
+        if not isinstance(hdata, dict):
+            continue
+        compact["harnesses"][hname] = {
+            "categories": hdata.get("categories"),
+            "finding_categories": sorted(
+                {cf.get("category", "?") for cf in (hdata.get("critical_failures") or [])}
+            ),
+        }
+
     context_parts = [
-        "=== CURRENT AUDIT RESULTS ===",
-        json.dumps(aggregate, indent=2, default=str),
+        "=== CURRENT COVERAGE (categories only — rates are in the digest) ===",
+        json.dumps(compact, indent=2, default=str),
     ]
 
     # Load README for coverage context
@@ -977,21 +1050,69 @@ def run_self_changelog(
     api_key: str,
     synthesizer: str | None = None,
     repo_root: Path | None = None,
-    days: int = 7,
-) -> str | None:
-    """Summarize recent changes to clawbio-bench itself.
+    last_bench_commit: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Summarize recent changes to clawbio-bench itself (incremental).
 
-    Runs ``git log`` and ``git diff`` on the benchmark repo to capture
-    what changed in the suite, then uses an LLM to produce a narrative.
+    Uses ``last_bench_commit..HEAD`` when a prior SHA is known, falling
+    back to ``--since=1 days ago`` on the first run.  Returns
+    ``(narrative, current_head_sha)`` so the caller can persist state.
     """
     import subprocess
 
     root = repo_root or Path(__file__).resolve().parent.parent
-    since = f"{days} days ago"
 
     try:
+        # Get current HEAD SHA for state tracking
+        head_r = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        current_sha = head_r.stdout.strip() if head_r.returncode == 0 else None
+
+        if last_bench_commit:
+            log_cmd = [
+                "git",
+                "-C",
+                str(root),
+                "log",
+                f"{last_bench_commit}..HEAD",
+                "--oneline",
+                "--no-merges",
+            ]
+            diff_cmd = [
+                "git",
+                "-C",
+                str(root),
+                "diff",
+                "--stat",
+                f"{last_bench_commit}..HEAD",
+            ]
+            range_label = f"since {last_bench_commit[:10]}"
+        else:
+            log_cmd = [
+                "git",
+                "-C",
+                str(root),
+                "log",
+                "--since=1 days ago",
+                "--oneline",
+                "--no-merges",
+            ]
+            diff_cmd = [
+                "git",
+                "-C",
+                str(root),
+                "diff",
+                "--stat",
+                "HEAD~1..HEAD",
+            ]
+            range_label = "last 24 hours"
+
         log_result = subprocess.run(
-            ["git", "-C", str(root), "log", f"--since={since}", "--oneline", "--no-merges"],
+            log_cmd,
             capture_output=True,
             text=True,
             timeout=10,
@@ -999,7 +1120,7 @@ def run_self_changelog(
         git_log = log_result.stdout.strip() if log_result.returncode == 0 else ""
 
         diff_result = subprocess.run(
-            ["git", "-C", str(root), "diff", "--stat", "HEAD~20..HEAD"],
+            diff_cmd,
             capture_output=True,
             text=True,
             timeout=10,
@@ -1007,12 +1128,12 @@ def run_self_changelog(
         git_stat = diff_result.stdout.strip() if diff_result.returncode == 0 else ""
     except Exception as exc:
         print(f"  Self-changelog: git failed ({exc}).", file=sys.stderr)
-        return None
+        return None, None
 
     if not git_log:
-        return None
+        return None, current_sha
 
-    context = f"=== GIT LOG (last {days} days) ===\n{git_log}"
+    context = f"=== GIT LOG ({range_label}) ===\n{git_log}"
     if git_stat:
         context += f"\n\n=== DIFF STAT ===\n{git_stat}"
 
@@ -1024,7 +1145,7 @@ def run_self_changelog(
 
     synth_model = synthesizer or DEFAULT_SYNTHESIZER_MODEL
     try:
-        return _openrouter_call(
+        narrative = _openrouter_call(
             synth_model,
             SELF_CHANGELOG_SYSTEM_PROMPT,
             context,
@@ -1032,9 +1153,10 @@ def run_self_changelog(
             temperature=0.1,
             max_tokens=8192,
         )
+        return narrative, current_sha
     except Exception as exc:
         print(f"  Self-changelog: LLM failed ({exc}).", file=sys.stderr)
-        return None
+        return None, current_sha
 
 
 def write_self_changelog_log(
@@ -1250,11 +1372,19 @@ def main() -> int:
     clawbio_raw: str | None = None
     repo_root = Path(__file__).resolve().parent.parent
 
+    # Load incremental state (last-processed SHAs)
+    log_state: dict = {}
+    if args.log_dir:
+        log_state = _load_log_state(args.log_dir)
+
     if not args.dry_run and api_key:
         # ClawBio diff analysis (if --clawbio-repo provided)
         clawbio_repo = getattr(args, "clawbio_repo", None)
         if clawbio_repo:
-            clawbio_raw = _get_clawbio_diff(clawbio_repo)
+            clawbio_raw = _get_clawbio_diff(
+                clawbio_repo,
+                last_clawbio_commit=log_state.get("last_clawbio_commit"),
+            )
             if clawbio_raw:
                 try:
                     clawbio_diff_text = _openrouter_call(
@@ -1277,13 +1407,21 @@ def main() -> int:
                 roadmap_path=repo_root / "ROADMAP.md",
             )
 
-        # Self-changelog
+        # Self-changelog (incremental — only new commits since last run)
         if args.self_changelog:
-            self_cl_text = run_self_changelog(
+            self_cl_text, new_bench_sha = run_self_changelog(
                 api_key,
                 synthesizer=args.llm_synthesizer,
                 repo_root=repo_root,
+                last_bench_commit=log_state.get("last_bench_commit"),
             )
+            if new_bench_sha:
+                log_state["last_bench_commit"] = new_bench_sha
+
+    # Persist current ClawBio commit for next run's diff range
+    clawbio_commit = aggregate.get("clawbio_commit")
+    if clawbio_commit:
+        log_state["last_clawbio_commit"] = clawbio_commit
 
     # Write consolidated daily log
     if args.log_dir and not args.dry_run:
@@ -1298,6 +1436,7 @@ def main() -> int:
             clawbio_raw_diff=clawbio_raw,
             api_key=api_key or None,
             synthesizer=args.llm_synthesizer,
+            aggregate=aggregate,
         )
 
         if args.weekly:
@@ -1313,6 +1452,9 @@ def main() -> int:
                 api_key=api_key or None,
                 synthesizer=args.llm_synthesizer,
             )
+
+        # Persist incremental state for next run
+        _save_log_state(args.log_dir, log_state)
 
     # Webhook
     if args.webhook and not args.dry_run:


### PR DESCRIPTION
## **User description**
## Summary

- Soften all LLM system prompts in daily audit pipeline (e.g. "worst performers" → "areas for improvement", "regression" → "declined")
- Fix `_verify_numbers` in polish pass — was passing empty `{}` for aggregate, allowing fabricated numbers through verification
- Make self-changelog incremental via last-SHA tracking in `baselines/log/state.json` (eliminates 6/7-day content overlap)
- Gate regression-sweep on actual pass-rate decline vs baseline
- Add `scripts/guard_ground_truth.py` for pre-commit ground truth validation

## Test plan

- [ ] Verify daily audit workflow runs cleanly with softened prompts
- [ ] Confirm `_verify_numbers` rejects fabricated aggregate stats
- [ ] Check incremental changelog produces no duplicate content across days


___

## **CodeAnt-AI Description**
**Neutralize audit language, reduce repeated log content, and tighten regression checks**

### What Changed
- Daily audit reports now use neutral wording in summaries, issue titles, and trend analysis, with “declined,” “areas for improvement,” and “recurring themes” replacing harsher language.
- The investigation section now focuses only on coverage gaps and new finding categories, instead of repeating per-harness pass-rate details already shown elsewhere.
- Self-changelog and ClawBio diff reports now track the last processed commit, so each daily run includes only new changes instead of overlapping the previous 6–7 days or reusing a rolling diff window.
- The daily audit workflow now downloads the latest rolling baseline before comparing results, and the regression-sweep job runs only when the current pass rate is actually lower than the baseline.
- The daily log polish step now verifies numbers against the original audit results, preventing fabricated values from surviving the final formatted report.

### Impact
`✅ Less repetitive daily reports`
`✅ Fewer false regression alerts`
`✅ Clearer audit findings`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=M0lI1DiFtiLZS4MjZ2940mQyxOCH2C0UtN_F65HH8zs)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
