### PR TITLE
fix: CodeAnt review — parse safety, guard scope

### DIFF
--- a/scripts/guard_ground_truth.py
+++ b/scripts/guard_ground_truth.py
@@ -51,10 +51,10 @@ def is_protected(file_path: str) -> tuple[bool, str]:
 
     for pattern, reason in PROTECTED_PATTERNS:
         if pattern in rel_posix:
-            # ground_truth.txt guard only applies to that specific filename
-            if pattern == "test_cases/":
-                if resolved.name != "ground_truth.txt":
-                    continue
+            if pattern == "test_cases/" and resolved.name != "ground_truth.txt":
+                continue
+            if pattern == "schemas/" and resolved.suffix.lower() != ".json":
+                continue
             return True, reason
 
     return False, ""
@@ -64,16 +64,15 @@ def main() -> None:
     if len(sys.argv) < 2:
         sys.exit(0)
 
-    file_path = sys.argv[1]
-    blocked, reason = is_protected(file_path)
-
-    if blocked:
-        print(
-            f"BLOCKED: {os.path.basename(file_path)} is a protected audit artifact.\n"
-            f"Reason: {reason}",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    for file_path in sys.argv[1:]:
+        blocked, reason = is_protected(file_path)
+        if blocked:
+            print(
+                f"BLOCKED: {os.path.basename(file_path)} is a protected audit artifact.\n"
+                f"Reason: {reason}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/src/clawbio_bench/harnesses/gwas_prs_harness.py
+++ b/src/clawbio_bench/harnesses/gwas_prs_harness.py
@@ -136,18 +136,24 @@ PERCENTILE_TOLERANCE = 0.5  # percentage points
 # ---------------------------------------------------------------------------
 
 
-def parse_prs_results(results_json_path: Path) -> list[dict[str, Any]]:
-    """Parse the PRS results JSON file produced by gwas_prs.py."""
+def parse_prs_results(results_json_path: Path) -> list[dict[str, Any]] | None:
+    """Parse the PRS results JSON file produced by gwas_prs.py.
+
+    Returns a list of result dicts on success (may be empty ``[]`` if the tool
+    intentionally produced an empty array), or ``None`` when the file is
+    missing, unreadable, or not valid JSON — so callers can distinguish
+    "tool chose to emit no results" from "output is broken".
+    """
     if not results_json_path.exists():
-        return []
+        return None
     try:
         with open(results_json_path) as f:
             data = json.load(f)
         if isinstance(data, list):
             return data
-        return []
+        return None  # valid JSON but wrong schema
     except (json.JSONDecodeError, OSError):
-        return []
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +163,7 @@ def parse_prs_results(results_json_path: Path) -> list[dict[str, Any]]:
 
 def score_prs_verdict(
     ground_truth: dict[str, Any],
-    results: list[dict[str, Any]],
+    results: list[dict[str, Any]] | None,
     exit_code: int,
 ) -> dict[str, Any]:
     """Score tool output against ground truth.
@@ -170,6 +176,10 @@ def score_prs_verdict(
         PGS_ID: str — which PGS score was tested
         FINDING_CATEGORY: str — expected verdict category
         SCORE_TOLERANCE: float (optional, default 1e-4)
+
+    ``results`` is ``None`` when the output file is missing/unreadable
+    (always ``missing_output``), or ``[]`` when the tool intentionally
+    produced an empty array (may be a valid low-coverage skip).
     """
     finding_category = ground_truth.get("FINDING_CATEGORY", "score_exact_match")
     expected_prs = ground_truth.get("EXPECTED_PRS")
@@ -194,6 +204,17 @@ def score_prs_verdict(
             "details": details,
         }
 
+    # None = file missing/unreadable/bad JSON — always an error, even for
+    # coverage tests (a parse failure is not a deliberate skip).
+    if results is None:
+        return {
+            "category": "missing_output",
+            "rationale": "PRS results JSON missing, unreadable, or invalid schema",
+            "details": details,
+        }
+
+    # Empty list = tool produced valid JSON with no entries.
+    # For coverage tests this is an intentional skip; otherwise it's an error.
     if not results:
         if finding_category == "coverage_correctly_flagged":
             return {
@@ -203,7 +224,7 @@ def score_prs_verdict(
             }
         return {
             "category": "missing_output",
-            "rationale": "No PRS results JSON found or empty",
+            "rationale": "PRS results JSON is an empty array",
             "details": details,
         }
 
@@ -394,11 +415,13 @@ def run_single_gwas_prs(
     results = parse_prs_results(results_json_path)
 
     report_analysis: dict[str, Any] = {
-        "results_count": len(results),
+        "results_count": len(results) if results is not None else 0,
+        "results_parse_ok": results is not None,
         "exit_code": execution.exit_code,
     }
     if results:
-        r = results[0]
+        # Match the same pgs_id that scoring uses, fall back to first entry
+        r = next((item for item in results if item.get("pgs_id") == pgs_id), results[0])
         report_analysis["observed_prs"] = r.get("raw_score")
         report_analysis["observed_percentile"] = r.get("percentile")
         report_analysis["observed_category"] = r.get("risk_category")


### PR DESCRIPTION
## **User description**
## Summary

- `parse_prs_results` returns `None` for missing/bad JSON vs `[]` for valid empty array, preventing misclassification of parse failures as coverage skips
- `guard_ground_truth.py` checks all argv paths (pre-commit passes multiple files)
- `schemas/` guard scoped to `.json` files only

## Test plan

- [x] `ruff check` passes
- [x] 245 unit tests pass


___

## **CodeAnt-AI Description**
**Treat missing PRS output differently from an intentional empty result**

### What Changed
- PRS runs now distinguish broken or missing JSON output from a valid empty array, so parse failures are reported as missing output instead of being mistaken for a coverage skip
- When PRS results are present, the report now uses the matching score entry for the tested PGS ID instead of always showing the first result
- The ground-truth guard now checks every file passed to it, and only blocks the intended protected files: `ground_truth.txt` under `test_cases/` and `.json` files under `schemas/`

### Impact
`✅ Fewer false coverage skips`
`✅ Clearer PRS failure reports`
`✅ Safer audit-file protection`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=U-RM9aHG8ApXovGB4ISxZ6tm0PV3mKuIHyRvRfxdPOU)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
